### PR TITLE
Use local overrides for JS

### DIFF
--- a/src/components/vf-componenet-rollup/scripts.js
+++ b/src/components/vf-componenet-rollup/scripts.js
@@ -10,8 +10,8 @@
 import { vfBanner } from "vf-banner/vf-banner";
 vfBanner();
 
-import { vfMastheadSetStyle } from "vf-masthead/vf-masthead";
-vfMastheadSetStyle();
+// import { vfMastheadSetStyle } from "vf-masthead/vf-masthead";
+// vfMastheadSetStyle();
 
 import { vfGaIndicateLoaded } from "vf-analytics-google/vf-analytics-google";
 let vfGaTrackOptions = {
@@ -22,8 +22,8 @@ vfGaIndicateLoaded(vfGaTrackOptions);
 import { vfTabs } from "vf-tabs/vf-tabs";
 vfTabs();
 
-import { vfTree } from "vf-tree/vf-tree";
-vfTree();
+// import { vfTree } from "vf-tree/vf-tree";
+// vfTree();
 
 // import { vfFormFloatLabels } from 'vf-form__core/assets/vf-form__float-labels.js';
 // vfFormFloatLabels();
@@ -53,3 +53,8 @@ vfTree();
 // emblNotifications();
 
 // No default invokation
+
+// Import local components
+import { vfLocalOverrides, getHallOfFameContributors } from 'vf-local-overrides/vf-local-overrides';
+vfLocalOverrides();
+getHallOfFameContributors();

--- a/src/components/vf-local-overrides/vf-local-overrides.js
+++ b/src/components/vf-local-overrides/vf-local-overrides.js
@@ -1,4 +1,3 @@
-console.log('in overrides..');
 // vf-local-overrides
 
 // Don't need JS? Then feel free to delete this file.
@@ -28,6 +27,7 @@ console.log('in overrides..');
   */
  function vfLocalOverrides(firstPassedVar) {
    firstPassedVar = firstPassedVar || 'defaultVal';
+   console.log('in overrides..');
    console.log('vfLocalOverrides invoked with a value of', firstPassedVar);
 }
 
@@ -44,16 +44,21 @@ console.log('in overrides..');
     }]
  */
 
-const HALL_OF_FAME_SPREADSHEET_URL = "https://spreadsheets.google.com/feeds/cells/1PzqB89rAN-mg0dWpiXw7cBuETNjPz3IYdTXXsph_9Ig/1/public/full?alt=json";
 
-async function getHallOfFameContributors(){
-  return await fetch(HALL_OF_FAME_SPREADSHEET_URL)
+function getHallOfFameContributors(){
+  const HALL_OF_FAME_SPREADSHEET_URL = "https://spreadsheets.google.com/feeds/cells/1PzqB89rAN-mg0dWpiXw7cBuETNjPz3IYdTXXsph_9Ig/1/public/full?alt=json";
+  fetch(HALL_OF_FAME_SPREADSHEET_URL)
     .then((data) => data.json())
     .then(result => parseGoogleSheetResult(result, 3));
 }
 
-
 const parseGoogleSheetResult = (response, columnCount = 1) => {
+  /* generator to generator array chunks */
+  const arrayChunks = (arr, size) =>
+  Array.from({ length: Math.ceil(arr.length / size) }, (v, i) =>
+    arr.slice(i * size, i * size + size)
+  );
+
   if (!response?.feed?.entry || columnCount <= 0) {
     throw new Error("Incorrect input to function!");
   }
@@ -75,17 +80,9 @@ const parseGoogleSheetResult = (response, columnCount = 1) => {
     }
     return o;
   });
-
+  console.log('jsonData',jsonData)
   return jsonData;
 };
-
-/* generator to generator array chunks */
-function* arrayChunks(array, chunkSize) {
-  for (let i = 0;i < array.length;i += chunkSize) {
-    yield array.slice(i, i + chunkSize);
-  }
-}
-
 
 
 
@@ -93,7 +90,7 @@ function* arrayChunks(array, chunkSize) {
 // vfLocalOverrides();
 
 // By default your component should be usable with js imports
-// export { vfLocalOverrides, getHallOfFameContributors };
+export { vfLocalOverrides, getHallOfFameContributors, parseGoogleSheetResult };
 //
 // // You should also import it at ./components/vf-core/scripts.js
 // // import { vfcomponentName } from '../components/raw/vf-component/vf-component.js';

--- a/src/site/_includes/layouts/base.njk
+++ b/src/site/_includes/layouts/base.njk
@@ -36,6 +36,7 @@
 
   </head>
   <body class="{{ bodyClass }} vf-body">
-        {{ content | safe }}
+    {{ content | safe }}
+    {% include 'footer.njk' %}
   </body>
 </html>


### PR DESCRIPTION
I know you've made a workaround but I still thought this was worth looking at as it's a chance to show how some things work with the VF JS. Here's a summary of what I've done:

- reinserted the footer.njk template so the local JS is executed
- in vf-rollup.js I imported the vf-local-overrides JS code
- made a few structural changes to the local code so it compiles better to ES5
   - there was nothing wrong with what you had done, but that approach added a dependency of [regenerator-runtime](https://www.npmjs.com/package/regenerator-runtime)
